### PR TITLE
Base64 Decode Improvements

### DIFF
--- a/fcp/node.py
+++ b/fcp/node.py
@@ -3255,17 +3255,15 @@ def base64decode(enc):
     Arguments:
      - enc - base64 string to decode
     """
-    # convert from Freenet alphabet to RFC1521 format
-    enc = enc.replace("~", "+")
-    enc = enc.replace("-", "/")
+    # TODO: Are underscores actually used anywhere?
     enc = enc.replace("_", "=")
 
     # Add padding. Freenet may omit it.
     while (len(enc) % 4) != 0:
         enc += '='
 
-    # now ready to decode
-    raw = base64.decodestring(enc)
+    # Now ready to decode. ~ instead of +; - instead of /.
+    raw = base64.b64decode(enc, '~-')
     
     return raw
 


### PR DESCRIPTION
The existing support for decoding Freenet's encoding method based on base64 did not restore padding characters, which Freenet may omit. See [Base64,java](https://github.com/freenet/fred-official/blob/build01444/src/freenet/support/Base64.java#L15).

I also noticed that the Python [base64 functions](http://docs.python.org/2/library/base64.html) (as of Python 2.4) can take an `altchars` argument which gives alternatives for `+` and `/`.
