### PR TITLE
Don't close the Node connection on JobTicket.getResult() exception

### DIFF
--- a/fcp/node.py
+++ b/fcp/node.py
@@ -3048,7 +3048,6 @@ class JobTicket:
         If result is an exception object, then raises it
         """
         if isinstance(self.result, Exception):
-            self.node.shutdown()
             raise self.result
         else:
             return self.result


### PR DESCRIPTION
There's no need to close the connection to the node here, and this
behaviour is undocumented. The previous behaviour did not allow users
to check whether the request, when it is completed, was successful or
not: `FCPGetFailed` is an `Exception` and would cause the connection to be
shut down.
